### PR TITLE
Explicitly set current working directory in gulpfile.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task('serve', ['styles'], () => {
     notify: false,
     port: 9000,
     server: {
-      baseDir: ['']
+      baseDir: ['./']
     }
   });
 


### PR DESCRIPTION
Thanks for this nice library!

I couldn't get the demo to work without explicitly setting the root path in `gulpfile.js` (see https://browsersync.io/docs/gulp).